### PR TITLE
Add ep+dp unit test forward pass

### DIFF
--- a/unit_test.sh
+++ b/unit_test.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ -z "$VENV_NAME" ]; then
-	VENV_NAME=../jaxmoe
+	VENV_NAME="/shared/$USER/aws_neuron_venv_pytorch"
 fi
 
 source $VENV_NAME/bin/activate
@@ -64,7 +64,7 @@ export NEURON_CC_FLAGS="${NEURON_CC_FLAGS} --auto-cast=none"
 
 export TF_CPP_MIN_LOG_LEVEL=3
 # # JAX Cache
-# export JAX_COMPILATION_CACHE_DIR="/shared/aahila/compiler/cache/"
+# export JAX_COMPILATION_CACHE_DIR="/shared/$USER/compiler/cache/"
 # mkdir -p ${JAX_COMPILATION_CACHE_DIR}
 
 # default set to presubmit/12B/50B/150B
@@ -96,4 +96,7 @@ elif [ "$1" = "150b_blockwise_cpu" ]; then
 elif [ "$1" = "150b_blockwise_neuron" ]; then
     pytest -rsA --tb=short axlearn/common/mixture_of_experts_neuron_test.py -k 'TestDev150bInteg and test_fwd_blockwise_vs_einsum or TestDev150bInteg and test_fwdbwd_blockwise_vs_einsum'
     pytest -rsA --tb=short axlearn/common/mixture_of_experts_neuron_test.py -k 'TestDev150bInteg and test_fwd_blockwisev2_vs_einsum or TestDev150bInteg and test_fwdbwd_blockwisev2_vs_einsum'
+elif [ "$1" = "150b_blockwise_neuron_ep" ]; then
+    export _USING_INDEX_EP_SHARDING=1
+    pytest -rsA --tb=short axlearn/common/mixture_of_experts_neuron_test.py -k 'TestDev150bUnitEP'
 fi


### PR DESCRIPTION
Add a `dp=8,ep=8` single node test, forward pass.

Key Changes:

* Add `calculate_token_position_to_id_ep_shard` function to compute token position ids across expert ranks.
* Add sharding constraints to router `logits`, `expert_affinities_masked`, and `expert_mask_after_dropping` to prevent unwanted propagation of expert sharding on `block_position_indices`.
* Remove `expert` sharding on the input tensor `O` dimension, so that each batch sees all experts. Support for input sharding along expert dimension planned for future PRs.
* New `TestDev150bUnitEP` class with modified 150b config, `seq=512`, `hidden_dim=4096` to avoid Collective operation ALLREDUCE size limit issue.

Testing:

* Verified neuron output tensor matches the golden cpu output tensor.
* Verified single all-reduce collective op the forward pass HLO - on the kernel output expert dimension.

```
 all-reduce = f32[1,1,512,8192]{3,2,1,0} all-reduce(reshape.715), channel_id=5, replica_groups={{0,1,2,3,4,5,6,7},{8,9,10,11,12,13,14,15},{16,17,18,19,20,21,22,23},{24,25,26,27,28,29,30,31},{32,33,34,35,36,37,38,39},{40,41,42,43,44,45,46,47},{48,49,50,51,52,53,54,55},{56,57,58,59,60,61,62,63}}, use_global_device_ids=true, to_apply=region_11.335.clone, frontend_attributes={has_token="0"}, metadata={op_name="jit(test_fwd_call)/jit(main)/root[TransformerFeedForwardMoE]/reduce_sum" source_file="/shared/arashj/release/axlearn/axlearn/common/mixture_of_experts.py" source_line=1933}
```