### PR TITLE
Add Expert Parallelism (EP) Testcases support to MoE testing framework

### DIFF
--- a/aws-testing/utils_neuron.py
+++ b/aws-testing/utils_neuron.py
@@ -55,7 +55,9 @@ def get_mesh_dims_from_spec(mesh_spec):
 def build_name(cfg, invoker_cfg):
     if invoker_cfg['mesh_spec']:
         fsdp = invoker_cfg['mesh_spec']['fsdp']
-        if 'model' in invoker_cfg['mesh_spec']:
+        if 'model' in invoker_cfg['mesh_spec'] and 'expert' in invoker_cfg['mesh_spec']:
+            mesh_str = f"fsdp{fsdp}tp{invoker_cfg['mesh_spec']['model']}ep{invoker_cfg['mesh_spec']['expert']}"
+        elif 'model' in invoker_cfg['mesh_spec']:
             mesh_str = f"fsdp{fsdp}tp{invoker_cfg['mesh_spec']['model']}"
         elif 'expert' in invoker_cfg['mesh_spec']:
             mesh_str = f"fsdp{fsdp}ep{invoker_cfg['mesh_spec']['expert']}"

--- a/aws-testing/utils_neuron.py
+++ b/aws-testing/utils_neuron.py
@@ -515,18 +515,19 @@ class GridSpaceBuilder:
         }
         
         for tp_degree, ep_degree in tp_ep_combinations:
-            if min_tp is not None and tp_degree < min_tp:
+            # Only respect min_tp for TP-only cases (ep_degree == 1)
+            # With EP, lower TP values can still fit the model
+            if min_tp is not None and ep_degree == 1 and tp_degree < min_tp:
                 continue
-            if max_tp is not None and tp_degree > max_tp:
+            if max_tp is not None and ep_degree == 1 and tp_degree > max_tp:
                 continue
                 
             #mesh_spec and batch based on parallelism type
             if ep_degree > 1:
                 mesh_spec = {"fsdp": -1, "expert": ep_degree}
-                batch = batch_sizes[ep_degree]
             else:
                 mesh_spec = {"fsdp": -1, "model": tp_degree}
-                batch = batch_sizes[tp_degree]
+            batch = batch_sizes[tp_degree]
             
             cf = 2
             
@@ -572,11 +573,26 @@ class GridSpaceBuilder:
         # TODO: consider removing DP replicas of groups and parallelize different tests on different cores if possible
         # Grid space for testing
         grid_space = []
-        # TODO add EP
-        for mesh_spec in [{"fsdp": -1, "model": 16}]:
-            batch = 4 if mesh_spec["model"] == 16 else 1
+        
+        mesh_configs = [
+            # TP-only configurations
+            ({"fsdp": -1, "model": 4}, 16, 1),      # TP=4, batch=16, n_groups=1
+            ({"fsdp": -1, "model": 16}, 4, 1),      # TP=16, batch=4, n_groups=1
+            ({"fsdp": -1, "model": 64}, 1, 1),      # TP=64, batch=1, n_groups=1
+            
+            # EP-only configurations
+            ({"fsdp": -1, "expert": 16}, 16, 16),   # EP=16, batch=16, n_groups=16
+            ({"fsdp": -1, "expert": 64}, 16, 64),   # EP=64, batch=16, n_groups=64
+            
+            # Mixed TP+EP configurations
+            ({"fsdp": -1, "model": 4, "expert": 16}, 16, 16),  # TP=4×EP=16, batch=16, n_groups=16
+        ]
+        
+        for mesh_spec, batch, n_groups in mesh_configs:
             for top_k in [1, 8]:
-                grid_space.append(self.create_test_config(**kwargs, top_k=top_k, batch=batch, mesh_spec=mesh_spec))
+                test_kwargs = kwargs.copy()
+                test_kwargs['n_groups'] = n_groups
+                grid_space.append(self.create_test_config(**test_kwargs, top_k=top_k, batch=batch, mesh_spec=mesh_spec))
         return grid_space
     
     def build_grid_space_switch_xxl(self):
@@ -593,11 +609,26 @@ class GridSpaceBuilder:
         # TODO: consider removing DP replicas of groups and parallelize different tests on different cores if possible
         # Grid space for testing
         grid_space = []
-        # TODO add EP
-        for mesh_spec in [{"fsdp": -1, "model": 64}]:
-            batch = 4 if mesh_spec["model"] == 16 else 1
+        
+        mesh_configs = [
+            # TP-only configurations
+            ({"fsdp": -1, "model": 4}, 16, 1),      # TP=4, batch=16, n_groups=1
+            ({"fsdp": -1, "model": 16}, 4, 1),      # TP=16, batch=4, n_groups=1
+            ({"fsdp": -1, "model": 64}, 1, 1),      # TP=64, batch=1, n_groups=1
+            
+            # EP-only configurations
+            ({"fsdp": -1, "expert": 16}, 16, 16),   # EP=16, batch=16, n_groups=16
+            ({"fsdp": -1, "expert": 64}, 16, 64),   # EP=64, batch=16, n_groups=64
+            
+            # Mixed TP+EP configurations
+            ({"fsdp": -1, "model": 4, "expert": 16}, 16, 16),  # TP=4×EP=16, batch=16, n_groups=16
+        ]
+        
+        for mesh_spec, batch, n_groups in mesh_configs:
             for top_k in [1, 2]:
-                grid_space.append(self.create_test_config(**kwargs, top_k=top_k, batch=batch, mesh_spec=mesh_spec))
+                test_kwargs = kwargs.copy()
+                test_kwargs['n_groups'] = n_groups
+                grid_space.append(self.create_test_config(**test_kwargs, top_k=top_k, batch=batch, mesh_spec=mesh_spec))
         return grid_space
 
     def build_grid_space_qwen3_235b(self):
@@ -616,9 +647,17 @@ class GridSpaceBuilder:
         grid_space = []
         
         mesh_configs = [
+            # TP-only configurations
+            ({"fsdp": -1, "model": 4}, 16, 1),      # TP=4, batch=16, n_groups=1
+            ({"fsdp": -1, "model": 16}, 4, 1),      # TP=16, batch=4, n_groups=1
             ({"fsdp": -1, "model": 64}, 1, 1),      # TP=64, batch=1, n_groups=1
-            ({"fsdp": -1, "expert": 16}, 4, 16),    # EP=16, batch=4, n_groups=16  
-            ({"fsdp": -1, "expert": 64}, 1, 64),    # EP=64, batch=1, n_groups=64
+            
+            # EP-only configurations
+            ({"fsdp": -1, "expert": 16}, 16, 16),   # EP=16, batch=16, n_groups=16
+            ({"fsdp": -1, "expert": 64}, 16, 64),   # EP=64, batch=16, n_groups=64
+            
+            # Mixed TP+EP configurations
+            ({"fsdp": -1, "model": 4, "expert": 16}, 16, 16),  # TP=4×EP=16, batch=16, n_groups=16
         ]
         
         for mesh_spec, batch, n_groups in mesh_configs:

--- a/aws-testing/utils_neuron.py
+++ b/aws-testing/utils_neuron.py
@@ -515,14 +515,13 @@ class GridSpaceBuilder:
         }
         
         for tp_degree, ep_degree in tp_ep_combinations:
-            # Only respect min_tp for TP-only cases (ep_degree == 1)
-            # With EP, lower TP values can still fit the model
+
             if min_tp is not None and ep_degree == 1 and tp_degree < min_tp:
                 continue
             if max_tp is not None and ep_degree == 1 and tp_degree > max_tp:
                 continue
                 
-            #mesh_spec and batch based on parallelism type
+            #mesh_spec
             if ep_degree > 1:
                 mesh_spec = {"fsdp": -1, "expert": ep_degree}
             else:
@@ -543,7 +542,7 @@ class GridSpaceBuilder:
                     if K >= E//4:
                         break
                     
-                    # Set n_groups based on parallelism type
+                    # n_groups based on parallelism type
                     if ep_degree > 1:
                         G_values = [ep_degree]  # n_groups = ep_degree for EP
                     else:
@@ -669,43 +668,67 @@ class GridSpaceBuilder:
         return grid_space
 
     def build_grid_space_12B(self):
-        # Grid space for testing
         grid_space = []
-        kwargs={
+        kwargs = {
             'dtype': jnp.bfloat16,
             'input_dim': 2048,
             'hidden_dim': 7168,
         }
+        
+        #Keeping existing TP-only
+        
+        # Base test
+        grid_space.append(self.create_test_config(**kwargs, n_experts=8, top_k=2, n_groups=2, capacity_factor=2, batch=16, seq=4096, mesh_spec={"fsdp":-1, "model":4}))
+        
+        # Top-K variations (TP=4 only)
         grid_space.extend([
-            # base
-            self.create_test_config(**kwargs, n_experts=8, top_k=2, n_groups=2, capacity_factor=2, batch=16, seq=4096, mesh_spec={"fsdp":-1, "model":4}),
-            # topk changes
             self.create_test_config(**kwargs, n_experts=8, top_k=1, n_groups=2, capacity_factor=2, batch=16, seq=4096, mesh_spec={"fsdp":-1, "model":4}),
             self.create_test_config(**kwargs, n_experts=8, top_k=4, n_groups=2, capacity_factor=2, batch=16, seq=4096, mesh_spec={"fsdp":-1, "model":4}),
-            # seqlen changes
-                # failed assertionError
+        ])
+        
+        # Sequence length variations (TP=4 only)
+        grid_space.extend([
             self.create_test_config(**kwargs, n_experts=8, top_k=2, n_groups=2, capacity_factor=2, batch=16, seq=256, mesh_spec={"fsdp":-1, "model":4}),
-                # failed assertionError
             self.create_test_config(**kwargs, n_experts=8, top_k=2, n_groups=2, capacity_factor=2, batch=16, seq=2048, mesh_spec={"fsdp":-1, "model":4}),
             self.create_test_config(**kwargs, n_experts=8, top_k=2, n_groups=2, capacity_factor=2, batch=16, seq=8192, mesh_spec={"fsdp":-1, "model":4}),
             self.create_test_config(**kwargs, n_experts=8, top_k=2, n_groups=2, capacity_factor=2, batch=16, seq=16*1024, mesh_spec={"fsdp":-1, "model":4}),
             self.create_test_config(**kwargs, n_experts=8, top_k=2, n_groups=2, capacity_factor=2, batch=16, seq=32*1024, mesh_spec={"fsdp":-1, "model":4}),
-            # tp8
-            # self.create_test_config(**kwargs, n_experts=8, top_k=2, n_groups=2, capacity_factor=2, batch=8, seq=4096, mesh_spec={"fsdp":-1, "model":8}),
+        ])
+        
+        # TP scaling tests (keep existing n_groups=2)
+        grid_space.extend([
             self.create_test_config(**kwargs, n_experts=8, top_k=2, n_groups=2, capacity_factor=2, batch=4, seq=4096, mesh_spec={"fsdp":-1, "model":16}),
-            # self.create_test_config(**kwargs, n_experts=8, top_k=2, n_groups=2, capacity_factor=2, batch=2, seq=4096, mesh_spec={"fsdp":-1, "model":32}),
             self.create_test_config(**kwargs, n_experts=8, top_k=2, n_groups=2, capacity_factor=2, batch=1, seq=4096, mesh_spec={"fsdp":-1, "model":64}),
-
-            # num experts
-                # failed broadcasting error
+        ])
+        
+        # Expert/group variations (TP=4 only) - All 4 original tests
+        grid_space.extend([
             self.create_test_config(**kwargs, n_experts=1, top_k=1, n_groups=2, capacity_factor=2, batch=16, seq=4096, mesh_spec={"fsdp":-1, "model":4}),
-                # failed assertionError
             self.create_test_config(**kwargs, n_experts=7, top_k=2, n_groups=2, capacity_factor=2, batch=16, seq=4096, mesh_spec={"fsdp":-1, "model":4}),
-            # num groups
             self.create_test_config(**kwargs, n_experts=8, top_k=2, n_groups=1, capacity_factor=2, batch=16, seq=4096, mesh_spec={"fsdp":-1, "model":4}),
-                # failed assertionError
             self.create_test_config(**kwargs, n_experts=8, top_k=2, n_groups=4, capacity_factor=2, batch=16, seq=4096, mesh_spec={"fsdp":-1, "model":4}),
         ])
+        
+        #EP-specific tests
+        ep_test_configs = [
+            # Basic EP functionality
+            ({"fsdp": -1, "expert": 16}, 16, 16, 16, 2),   # EP=16, n_experts=16, top_k=2
+            
+            # EP with different expert counts (similar to original n_experts variations)
+            ({"fsdp": -1, "expert": 16}, 16, 16, 32, 2),  # EP=16, n_experts=32, top_k=2, is expert=32 allowed?
+            
+            # Mixed TP+EP test
+            ({"fsdp": -1, "model": 4, "expert": 16}, 16, 16, 16, 2),  # TP×EP=64
+            
+            # EP=64 test
+            ({"fsdp": -1, "expert": 64}, 16, 64, 128, 2),   # EP=64, n_experts=128, top_k=2
+        ]
+        
+        for mesh_spec, batch, n_groups, n_experts, top_k in ep_test_configs:
+            test_kwargs = kwargs.copy()
+            test_kwargs['n_groups'] = n_groups
+            grid_space.append(self.create_test_config(**test_kwargs, n_experts=n_experts, top_k=top_k, capacity_factor=2, batch=batch, seq=4096, mesh_spec=mesh_spec))
+        
         return grid_space
 
     def build_grid_space_50B(self):
@@ -743,6 +766,31 @@ class GridSpaceBuilder:
             self.create_test_config(**kwargs, n_experts=8, top_k=2, n_groups=1, capacity_factor=2, batch=16, seq=4096, mesh_spec={"fsdp":-1, "model":4}),
             self.create_test_config(**kwargs, n_experts=8, top_k=2, n_groups=4, capacity_factor=2, batch=16, seq=4096, mesh_spec={"fsdp":-1, "model":4}),
         ])
+
+        #EP-specific tests 
+        ep_test_configs = [
+            # Basic EP functionality
+            ({"fsdp": -1, "expert": 16}, 16, 16, 16, 2),   # EP=16, n_experts=16, top_k=2
+            ({"fsdp": -1, "expert": 16}, 16, 16, 16, 2),   # EP=16, n_experts=16, top_k=4
+            
+            # EP with different expert counts
+            ({"fsdp": -1, "expert": 16}, 16, 16, 32, 2),   # EP=16, n_experts=32, top_k=2
+            ({"fsdp": -1, "expert": 16}, 16, 16, 32, 4),   # EP=16, n_experts=32, top_k=4
+            
+            # Mixed TP+EP test
+            ({"fsdp": -1, "model": 4, "expert": 16}, 16, 16, 16, 2),  # TP=4×EP=16, n_experts=16
+            ({"fsdp": -1, "model": 4, "expert": 16}, 16, 16, 16, 4),  # TP=4×EP=16, n_experts=16, topk=4
+            
+            # EP=64 test
+            ({"fsdp": -1, "expert": 64}, 16, 64, 64, 2),   # EP=64, n_experts=64, top_k=2
+            ({"fsdp": -1, "expert": 64}, 16, 64, 64, 4),   # EP=64, n_experts=64, top_k=4
+        ]
+        
+        for mesh_spec, batch, n_groups, n_experts, top_k in ep_test_configs:
+            test_kwargs = kwargs.copy()
+            test_kwargs['n_groups'] = n_groups
+            grid_space.append(self.create_test_config(**test_kwargs, n_experts=n_experts, top_k=top_k, capacity_factor=2, batch=batch, seq=4096, mesh_spec=mesh_spec))
+        
         return grid_space
 
     def build_grid_space_150B(self):
@@ -787,13 +835,27 @@ class GridSpaceBuilder:
             #batch per TP-group
             self.create_test_config(dtype=jnp.bfloat16, input_dim=8192, hidden_dim=16384, n_experts=8, top_k=2, n_groups=1, capacity_factor=2, batch=8, seq=4096, mesh_spec={"fsdp":-1, "model":16}),
             self.create_test_config(dtype=jnp.bfloat16, input_dim=8192, hidden_dim=16384, n_experts=8, top_k=2, n_groups=1, capacity_factor=2, batch=16, seq=4096, mesh_spec={"fsdp":-1, "model":16}),
+            ])
             
-            # EP test cases for 16 experts
-            # EP=16 with TP=1
-            self.create_test_config(**kwargs, n_experts=16, top_k=4, n_groups=16, capacity_factor=2, batch=4, seq=8192, mesh_spec={"fsdp":-1, "expert":16}),
-            # EP=16 with TP=4  
-            self.create_test_config(**kwargs, n_experts=16, top_k=4, n_groups=16, capacity_factor=2, batch=4, seq=8192, mesh_spec={"fsdp":-1, "expert":16, "model":4}),
-        ])
+        #EP test cases
+        ep_test_configs = [
+            # EP=16 tests
+            ({"fsdp": -1, "expert": 16}, 16, 16, 16, 4),   # EP=16, n_experts=16, top_k=4
+            ({"fsdp": -1, "expert": 16}, 16, 16, 32, 2),   # EP=16, n_experts=32, top_k=2
+            
+            # Mixed TP+EP test  
+            ({"fsdp": -1, "model": 4, "expert": 16}, 16, 16, 16, 4),  # TP=4×EP=16, n_experts=16
+            
+            # EP=64 test
+            ({"fsdp": -1, "expert": 64}, 16, 64, 64, 2),   # EP=64, n_experts=64, top_k=2
+            ({"fsdp": -1, "expert": 64}, 16, 64, 64, 4),   # EP=64, n_experts=64, top_k=4
+            ]
+
+        for mesh_spec, batch, n_groups, n_experts, top_k in ep_test_configs:
+            test_kwargs = kwargs.copy()
+            test_kwargs['n_groups'] = n_groups
+            grid_space.append(self.create_test_config(**test_kwargs, n_experts=n_experts, top_k=top_k, capacity_factor=2, batch=batch, seq=8192, mesh_spec=mesh_spec))
+        
         return grid_space
 
 def get_gating_config(gating_cls, num_experts, top_k, train_capacity_factor, expert_capacity, block_size=None, name=None):

--- a/aws-testing/utils_neuron.py
+++ b/aws-testing/utils_neuron.py
@@ -54,7 +54,13 @@ def get_mesh_dims_from_spec(mesh_spec):
 
 def build_name(cfg, invoker_cfg):
     if invoker_cfg['mesh_spec']:
-        mesh_str = f"fsdp{invoker_cfg['mesh_spec']['fsdp']}tp{invoker_cfg['mesh_spec']['model']}"
+        fsdp = invoker_cfg['mesh_spec']['fsdp']
+        if 'model' in invoker_cfg['mesh_spec']:
+            mesh_str = f"fsdp{fsdp}tp{invoker_cfg['mesh_spec']['model']}"
+        elif 'expert' in invoker_cfg['mesh_spec']:
+            mesh_str = f"fsdp{fsdp}ep{invoker_cfg['mesh_spec']['expert']}"
+        else:
+            mesh_str = ''
     else:
         mesh_str = ''
 
@@ -494,31 +500,57 @@ class GridSpaceBuilder:
             32: 2,
             64: 1,
         }
-        tp_degrees = [4, 16, 64]
-        tp_degrees = [d for d in tp_degrees if min_tp is None or d >= min_tp]
-        tp_degrees = [d for d in tp_degrees if max_tp is None or d <=  max_tp]
+        # All tp,ep tuples
+        tp_ep_combinations = [
+            (1, 16), (1, 64),
+            (4, 1), (4, 16), 
+            (16, 1), 
+            (64, 1), 
+        ]
+        
         kwargs={
             'dtype': dtype,
             'input_dim': int(input_dim),
             'hidden_dim': int(hidden_dim),
         }
-        for tp_degree in tp_degrees:
-            mesh_spec = {"fsdp": -1, "model": tp_degree}
-            batch = batch_sizes[tp_degree]
-            for E in [1, 8, 16, 64, 128, 256]:
+        
+        for tp_degree, ep_degree in tp_ep_combinations:
+            if min_tp is not None and tp_degree < min_tp:
+                continue
+            if max_tp is not None and tp_degree > max_tp:
+                continue
+                
+            #mesh_spec and batch based on parallelism type
+            if ep_degree > 1:
+                mesh_spec = {"fsdp": -1, "expert": ep_degree}
+                batch = batch_sizes[ep_degree]
+            else:
+                mesh_spec = {"fsdp": -1, "model": tp_degree}
+                batch = batch_sizes[tp_degree]
+            
+            cf = 2
+            
+            for E in [1, 8, 16, 128 ]:
                 if max_E and E > max_E:
-                    # to skip large Es for large experts
                     break
                 if E >= 64 and tp_degree < 16:
                     continue
-                # min sparsity of 25% assumed
+                if E < ep_degree:  #making sure that E >= ep
+                    continue
+                    
                 for K in [1, 2, 4, 8, 16]:
                     if K >= E//4:
                         break
-                    for G in [1, 4]:
+                    
+                    # Set n_groups based on parallelism type
+                    if ep_degree > 1:
+                        G_values = [ep_degree]  # n_groups = ep_degree for EP
+                    else:
+                        G_values = [1, 4]
+                    
+                    for G in G_values:
                         if G > E:
                             break
-                        cf = 2
                         S = min_seq
                         while (max_seq and S <= max_seq) or (S <= 16*1024):
                             grid_space.append(self.create_test_config(**kwargs, n_experts=E, top_k=K, n_groups=G, capacity_factor=cf, seq=S, batch=batch, mesh_spec=mesh_spec))
@@ -582,11 +614,19 @@ class GridSpaceBuilder:
         # TODO: consider removing DP replicas of groups and parallelize different tests on different cores if possible
         # Grid space for testing
         grid_space = []
-        # TODO add EP
-        for mesh_spec in [{"fsdp": -1, "model": 64}]:
-            batch = 4 if mesh_spec["model"] == 16 else 1
+        
+        mesh_configs = [
+            ({"fsdp": -1, "model": 64}, 1, 1),      # TP=64, batch=1, n_groups=1
+            ({"fsdp": -1, "expert": 16}, 4, 16),    # EP=16, batch=4, n_groups=16  
+            ({"fsdp": -1, "expert": 64}, 1, 64),    # EP=64, batch=1, n_groups=64
+        ]
+        
+        for mesh_spec, batch, n_groups in mesh_configs:
             for top_k in [1, 8]:
-                grid_space.append(self.create_test_config(**kwargs, top_k=top_k, batch=batch, mesh_spec=mesh_spec))
+                test_kwargs = kwargs.copy()
+                test_kwargs['n_groups'] = n_groups
+                grid_space.append(self.create_test_config(**test_kwargs, top_k=top_k, batch=batch, mesh_spec=mesh_spec))
+        
         return grid_space
 
     def build_grid_space_12B(self):
@@ -708,6 +748,12 @@ class GridSpaceBuilder:
             #batch per TP-group
             self.create_test_config(dtype=jnp.bfloat16, input_dim=8192, hidden_dim=16384, n_experts=8, top_k=2, n_groups=1, capacity_factor=2, batch=8, seq=4096, mesh_spec={"fsdp":-1, "model":16}),
             self.create_test_config(dtype=jnp.bfloat16, input_dim=8192, hidden_dim=16384, n_experts=8, top_k=2, n_groups=1, capacity_factor=2, batch=16, seq=4096, mesh_spec={"fsdp":-1, "model":16}),
+            
+            # EP test cases for 16 experts
+            # EP=16 with TP=1
+            self.create_test_config(**kwargs, n_experts=16, top_k=4, n_groups=16, capacity_factor=2, batch=4, seq=8192, mesh_spec={"fsdp":-1, "expert":16}),
+            # EP=16 with TP=4  
+            self.create_test_config(**kwargs, n_experts=16, top_k=4, n_groups=16, capacity_factor=2, batch=4, seq=8192, mesh_spec={"fsdp":-1, "expert":16, "model":4}),
         ])
         return grid_space
 


### PR DESCRIPTION
# MoE Testing Framework Updates

## High-Level Summary

Enhanced the MoE (Mixture of Experts) testing framework in `utils_neuron.py` to support comprehensive Expert Parallelism (EP) testing alongside existing Tensor Parallelism (TP) configurations. The changes enable testing of various parallelism strategies for large-scale MoE models including 150B and Qwen3-235B configurations.

## Key Changes

### 1. Enhanced `build_name` Function
- **Purpose**: Improved test case naming to distinguish between TP and EP configurations
- **Changes**: 
  - Added support for `expert` mesh specifications in naming
  - Enhanced mesh string generation to show `ep{N}` for expert parallelism vs `tp{N}` for tensor parallelism
  - Better identification of test configurations in logs and results

### 2. Updated `build_grid_space_input_hidden` Function
- **Purpose**: Core function for generating test configurations with various parallelism combinations
- **Key Updates**:
  - **TP/EP Combinations**: Supports combinations like (1,16), (1,64), (4,1), (4,16), (16,1), (64,1)
  - **Constraint**: Maximum product of TP×EP ≤ 64 (Trn2 architecture limit)
  - **Mesh Specification Logic**:
    - EP > 1: `{"fsdp": -1, "expert": ep_degree}` with `n_groups = ep_degree`
    - TP only: `{"fsdp": -1, "model": tp_degree}` with `n_groups ∈ [1, 4]`
  - **Batch Size Mapping**: Appropriate batch sizes for different parallelism degrees (64→1, 16→4, 4→16)

### 3. Enhanced `build_grid_space_150B` Function
- **Purpose**: Specific test configurations for 150B model scale
- **New Features**:
  - **EP Test Cases**: Added EP=16 configurations for 16-expert scenarios
  - **Configurations**:
    - EP=16 with TP=1: `mesh_spec={"fsdp": -1, "expert": 16}`
    - EP=16 with TP=4: `mesh_spec={"fsdp": -1, "expert": 16, "model": 4}`
  - **Model Dimensions**: 6144→15360 hidden dimensions
  - **Expert Counts**: Supports 8 and 16 experts with appropriate group configurations

### 4. New `build_grid_space_qwen3_235b` Function
- **Purpose**: Comprehensive testing for Qwen3-235B model with both TP and EP strategies
- **Configurations**:
  - **TP=64**: `mesh_spec={"fsdp": -1, "model": 64}`, `n_groups=1`, `batch=1`
  - **EP=16**: `mesh_spec={"fsdp": -1, "expert": 16}`, `n_groups=16`, `batch=4`
  - **EP=64**: `mesh_spec={"fsdp": -1, "expert": 64}`, `n_groups=64`, `batch=1`
- **Model Specifications**:
  - Input dimension: 4096
  - Hidden dimension: 12288
  - Experts: 128
  - Sequence length: 16384
  - Top-k values: [1, 8]

## Technical Details

### Parallelism Strategy Logic
- **Expert Parallelism (EP)**: `n_groups = ep_degree` ensures proper load balancing across expert-parallel processes
- **Tensor Parallelism (TP)**: `n_groups ∈ [1, 4]` for different input splitting strategies
- **Constraint Enforcement**: `n_experts ≥ ep_degree` to ensure sufficient experts per EP process

### Batch Size Optimization
```python
batch_sizes = {
    4: 16,   # Lower parallelism → higher batch size
    8: 8,
    16: 4,   # EP=16 uses batch=4
    32: 2,
    64: 1,   # EP=64 uses batch=1 (highest parallelism)
}
```

### Test Coverage
- **Switch-Base**: Uses `build_grid_space_input_hidden` with 1536→6144 dimensions
- **150B Models**: Uses `build_grid_space_150B` with 6144→15360 dimensions  
- **Qwen3-235B**: Uses `build_grid_space_qwen3_235b` with 4096→12288 dimensions

## Usage

### Running Tests
```bash
# Switch-base with EP configurations
sbatch aws-testing/test.slurm switch-base

# 150B development tests
sbatch aws-testing/test.slurm 150b

# Qwen3-235B with TP/EP combinations
sbatch aws-testing/test.slurm qwen3-235b
```

### Expected Test Cases
- **Switch-Base**: ~32 test configurations covering EP=16, TP=4, TP=16 with various expert counts
- **150B**: Enhanced with EP=16 test cases for 16-expert scenarios
- **Qwen3-235B**: 6 test configurations (3 parallelism strategies × 2 top-k values)
