### PR TITLE
upgraded pjrt flags and fuji.py(RepeatedTransformerLayer)

### DIFF
--- a/axlearn/experiments/text/gpt/fuji.py
+++ b/axlearn/experiments/text/gpt/fuji.py
@@ -171,7 +171,7 @@ def _generate_trn2_custom_configs(
         # So compile time does not grow with the number of layers.
         ModuleConfigModifier.default_config().set(
             target_config="model.decoder.transformer",
-            modification=StackedTransformerLayer.default_config(),
+            modification=RepeatedTransformerLayer.default_config(),
         )
     ]
     # Grouped QKV is only used in fuji-v3 except in fuji-v2 if model is 70B.
@@ -645,7 +645,7 @@ def get_trainer_kwargs(
     elif model_size == "70B":
         trainer_kwargs = dict(
             model_kwargs=dict(
-                num_layers=80,
+                num_layers=int(os.getenv("AXLEARN_NUM_LAYERS",80)),
                 hidden_dim=128 * 64,
                 num_heads=64,
                 # No GQA support in V1 models, so num_kv_heads is the same as num_heads.
@@ -657,10 +657,13 @@ def get_trainer_kwargs(
                 flash_attention=flash_attention,
             ),
             learner_kwargs=dict(peak_lr=1.5e-4, weight_decay=0.1),
-            max_sequence_length=max_sequence_length,
-            train_batch_size=train_batch_size,
+            max_sequence_length=int(os.getenv("AXLEARN_MAX_SEQUENCE_LENGTH",MAX_SEQUENCE_LENGTH[version])),
+            train_batch_size=int(os.getenv("AXLEARN_TRAIN_BATCH_SIZE", train_batch_size)),
             max_step=max_step,
-            mesh_shape=mesh_shape_from_axes(fsdp=-1),
+            mesh_shape=mesh_shape_from_axes(
+                fsdp=int(os.getenv("AXLEARN_FSDP_DEGREE", -1)), 
+                model=int(os.getenv("AXLEARN_TP_DEGREE", 4))
+                ),
             mesh_rules=(
                 # TPU V5e maximum per device batch is 1.
                 # with all activation offloading, HBM usage: 14.6GB/chip.
@@ -798,7 +801,10 @@ def get_trainer_kwargs(
                             MeshShapeModifier.default_config().set(
                                 # TP within the chip, FSDP across chips.
                                 # Each TRN2 chip has 4 XLA cores.
-                                mesh_shape=mesh_shape_from_axes(fsdp=-1, model=4)
+                                mesh_shape=mesh_shape_from_axes(
+                                    fsdp=int(os.getenv("AXLEARN_FSDP_DEGREE", -1)), 
+                                    model=int(os.getenv("AXLEARN_TP_DEGREE", 4))
+                                    )
                             ),
                             RematSpecModifier.default_config().set(
                                 remat_policies={
@@ -905,7 +911,7 @@ def model_config(
         hidden_dim=hidden_dim,
         num_heads=num_heads,
         vocab_size=vocab_size,
-        stack_cfg=stack_cfg if stack_cfg is not None else RepeatedTransformerLayer.default_config(),
+        stack_cfg=RepeatedTransformerLayer.default_config(),
         activation_fn=activation_fn,
         ffn_dim=ffn_dim,
         normalization=RMSNorm.default_config().set(eps=1e-5, forward_dtype=None),

--- a/runner.sh
+++ b/runner.sh
@@ -39,33 +39,47 @@ RT_PROFILE_DUMP_PATH=${TEST_ARTIFACTS_PATH}/rt_profiles
 
 # PJRT Flags 
 if [ "$AXLEARN_REPEATED" = "1" ]; then
-	export NEURON_FSDP_REPEATED=1
+	export NEURON_FSDP_REPEATED=1 # For RepeatedTransformerLayer
 	export NEURON_INTERNAL_CPU_NUM_THREADS=1
 	# ,neuron-token-threading-repeated
-	export XLA_FLAGS="--xla_disable_hlo_passes=aws_neuron_flip_all_gather_dot,neuron-hierarchical-collectives,neuron_move_all_gather_while_loop,neuron-fixed-point-collectives-combiner"
+	export NEURON_FSDP_REPEATED_CC_PIPELINING=1 #enables pipelining
+	
+	#export XLA_FLAGS="--xla_disable_hlo_passes=aws_neuron_flip_all_gather_dot,neuron-hierarchical-collectives,neuron_move_all_gather_while_loop,neuron-fixed-point-collectives-combiner"
+	export XLA_FLAGS="--xla_disable_hlo_passes=aws_neuron_flip_all_gather_dot,neuron-hierarchical-collectives" # including two more passes
+
+	export NEURON_FSDP_NUM_LAYER_COALESCE=-1 # coalesce all layers when RepeatedTransformerLayer is used
+	export NEURON_FSDP_NUM_LAYER_LATE_RS_SHIFT=2
+	export NEURON_DISABLE_MOVEMENT_OF_SLICE_FROM_PARAM=1
+
 else
 	# cancel-all-gather-dynamic-slice-2d
 	export XLA_FLAGS="--xla_disable_hlo_passes=aws_neuron_flip_all_gather_dot,neuron-hierarchical-collectives"
-	export NEURON_FSDP_NUM_LAYER_EARLY_AG_SHIFT=2
-	export NEURON_FSDP=1
+	export NEURON_FSDP=1 # For StackedTransformerLayer
 	if [ -n "$CUSTOM_TAG_rsshift" ]; then
 		export NEURON_FSDP_NUM_LAYER_LATE_RS_SHIFT=$CUSTOM_TAG_rsshift
 	else
 		# unset
-		export NEURON_FSDP_NUM_LAYER_LATE_RS_SHIFT=3
+		export NEURON_FSDP_NUM_LAYER_LATE_RS_SHIFT=2
 	fi
-	export NEURON_FSDP_NUM_LAYER_COALESCE=-1
+	export NEURON_FSDP_NUM_LAYER_COALESCE=1
 fi
+
 # 10 also was fast enough for a particular set of nodes
 # export NEURON_REMAT_LARGE_BROADCAST_MIN_SIZE_IN_MB=100
 export NEURON_COLLECTIVE_PERMUTE_TO_ALL_GATHER=1
 export NEURON_ENABLE_INT_MATMUL_DOWNCAST=1
-export NEURON_FSDP_CC_MULTISTREAM=0
+export NEURON_FSDP_CC_MULTISTREAM=1 #enables tp and fsdp collectives on different streams
+export NEURON_WHILE_LOOP_UNROLL=1
 export NEURON_RUN_TRIVIAL_COMPUTATION_ON_CPU=1
 export NEURON_HLO_ANALYZER=1
+export NEURON_FSDP_NUM_LAYER_EARLY_AG_SHIFT=1
+
 export XLA_FLAGS="${XLA_FLAGS} --xla_dump_hlo_as_proto"
 export XLA_FLAGS="${XLA_FLAGS} --xla_dump_hlo_as_text --xla_dump_to=${HLO_DUMP_PATH} --xla_dump_hlo_pass_re='.*'"
 
+export NEURON_RT_LOCAL_CORE_DUMP_DIRECTORY="" # critical to get the profiles dumped
+export AXLEARN_PROFILE_MODE="tracerun"
+export PROFILE_JOB_NAME=fuji_ntff
 
 # Neuron runtime flags
 export NEURON_SCRATCHPAD_PAGE_SIZE=1024
@@ -99,9 +113,12 @@ export NEURON_CC_FLAGS="${NEURON_CC_FLAGS} --enable-mixed-precision-accumulation
 export NEURON_CC_FLAGS="${NEURON_CC_FLAGS} -O1"
 
 
-export NEURON_CC_FLAGS="${NEURON_CC_FLAGS} --tensorizer-options='--enable-hoist-fsdp-collectives'"
+export NEURON_CC_FLAGS="${NEURON_CC_FLAGS} --tensorizer-options='--enable-hoist-fsdp-collectives --enable-d2d-pf-transpose-kernel'"
 export NEURON_CC_FLAGS="${NEURON_CC_FLAGS} --auto-cast=none"
 export NEURON_CC_FLAGS="${NEURON_CC_FLAGS} --hbm-scratchpad-page-size=1024"
+
+export NEURON_CC_FLAGS="${NEURON_CC_FLAGS} --internal-enable-dge-levels spill_reload --internal-backend-options=' --spill-reload-dmas-use-swdge '"
+export NEURON_CC_FLAGS="${NEURON_CC_FLAGS} --dump=${NEURON_DUMP_PATH}"
 
 if [ "$AXLEARN_REPEATED" = "1" ]; then
 	export NEURON_CC_FLAGS="${NEURON_CC_FLAGS} --internal-hlo2tensorizer-options='--recursive-layer-det=false --dump-after-to-file=pre-par-pipe-end,post-par-pipe-begin --remat-rope=false --verify-hlo'"

--- a/setup_node.sh
+++ b/setup_node.sh
@@ -36,7 +36,7 @@ sudo apt-get install -y google-perftools
 # Binaries to use:
 ###
 
-ENV_DROP_DIR=${1:-../mar-artifacts}
+ENV_DROP_DIR=${1:-/fsx/akshiaws/jul-end-artifacts}
 
 RUNTIME=$ENV_DROP_DIR/aws-neuronx-runtime-lib-*.deb
 COLLECTIVES=$ENV_DROP_DIR/aws-neuronx-collectives-*.deb


### PR DESCRIPTION
Updated subsequent PJRT flags for RepeatedTransformerLayer using NEURON_FSDP_REPEATED.
Moved fuji.py from using StackedTransformerLayer to RepeatedTransformerLayer.

Important PJRT flags:
NEURON_FSDP_REPEATED=1 
NEURON_FSDP_REPEATED_CC_PIPELINING=1 (overlaps AG and RS)
NEURON_FSDP_CC_MULTISTREAM=1 (enables tp and fsdp collectives on different streams)
NEURON_FSDP_NUM_LAYER_COALESCE=-1 (for RepeatedTransformerLayer and 1 for StackedTransformerLayer)[coalesces AG and RS]
NEURON_FSDP_NUM_LAYER_LATE_RS_SHIFT=2 (layer late to delay RS)
NEURON_FSDP_NUM_LAYER_EARLY_AG_SHIFT=1 (early AG)

Appended NEURON_CC_FLAGS

Fuji.py
Pulled out variables from runner.sh (AXLEARN_NUM_LAYERS, AXLEARN_TRAIN_BATCH_SIZE, AXLEARN_TP_DEGREE, AXLEARN_MAX_SEQUENCE_LENGTH, AXLEARN_FSDP_DEGREE) 

Subsequent PRs will have changes to runner.sh and fuji.py(to make sure changes do not affect pipelines)


Testing:
Fuji 70B test generating loss - s3://akshiaws-tempdata/fuji-akshiaws/passing.out